### PR TITLE
Fix neu_manager loop to use the correct pipe when sub/unsub node

### DIFF
--- a/src/core/neu_manager.c
+++ b/src/core/neu_manager.c
@@ -1415,8 +1415,8 @@ static void manager_loop(void *arg)
             nng_mtx_unlock(manager->adapters_mtx);
             msg_size = msg_inplace_data_get_size(sizeof(subscribe_node_cmd_t));
             rv       = nng_msg_alloc(&out_msg, msg_size);
-            need_forward = sub_grp_config_with_pipe(cmd_ptr->grp_config,
-                                                    nng_msg_get_pipe(msg));
+            need_forward = sub_grp_config_with_pipe(
+                cmd_ptr->grp_config, sub_reg_entity->adapter_pipe);
             if (rv == 0 && need_forward == 1) {
                 message_t *           msg_ptr;
                 subscribe_node_cmd_t *out_cmd_ptr;
@@ -1463,8 +1463,8 @@ static void manager_loop(void *arg)
             msg_size =
                 msg_inplace_data_get_size(sizeof(unsubscribe_node_cmd_t));
             rv           = nng_msg_alloc(&out_msg, msg_size);
-            need_forward = unsub_grp_config_with_pipe(cmd_ptr->grp_config,
-                                                      nng_msg_get_pipe(msg));
+            need_forward = unsub_grp_config_with_pipe(
+                cmd_ptr->grp_config, sub_reg_entity->adapter_pipe);
             if (rv == 0 && need_forward == 1) {
                 message_t *             msg_ptr;
                 unsubscribe_node_cmd_t *out_cmd_ptr;


### PR DESCRIPTION
  1. When handling MSG_CMD_SUBSCRIBE_NODE, use the pipe of the
     destination node
  2. When handling MSG_CMD_UNSUBSCRIBE_NODE, use the pipe of the
     destination node