### PR TITLE
Refactor code for implemenation of subscription persistence

### DIFF
--- a/src/core/message.c
+++ b/src/core/message.c
@@ -149,3 +149,15 @@ void *msg_get_buf_ptr(message_t *msg)
         return msg->inp_buf.buf_ptr;
     }
 }
+
+nng_msg *nng_msg_inplace_from_buf(msg_type_e msg_type, void *buf, size_t size)
+{
+    nng_msg *msg      = NULL;
+    size_t   msg_size = msg_inplace_data_get_size(size);
+    int      rv       = nng_msg_alloc(&msg, msg_size);
+    if (rv == 0) {
+        message_t *msg_ptr = nng_msg_body(msg);
+        msg_with_struct_init(msg_ptr, msg_type, buf, size);
+    }
+    return msg;
+}

--- a/src/core/message.h
+++ b/src/core/message.h
@@ -216,4 +216,7 @@ void msg_external_data_uninit(message_t *msg);
 msg_type_e msg_get_type(message_t *msg);
 size_t     msg_get_buf_len(message_t *msg);
 void *     msg_get_buf_ptr(message_t *msg);
+
+nng_msg *nng_msg_inplace_from_buf(msg_type_e msg_type, void *buf, size_t size);
+
 #endif

--- a/src/core/neu_manager.c
+++ b/src/core/neu_manager.c
@@ -422,6 +422,23 @@ static adapter_id_t manager_new_adapter_id(neu_manager_t *manager)
     nng_mtx_unlock(manager->adapters_mtx);
     return adapter_id;
 }
+
+static inline int manager_send_msg_to_pipe(neu_manager_t *manager,
+                                           nng_pipe pipe, msg_type_e msg_type,
+                                           void *buf, size_t size)
+{
+    nng_msg *msg = nng_msg_inplace_from_buf(msg_type, buf, size);
+    if (NULL == msg) {
+        return NEU_ERR_ENOMEM;
+    }
+    nng_msg_set_pipe(msg, pipe);
+    int rv = nng_sendmsg(manager->bind_info.mng_sock, msg, 0);
+    if (0 != rv) {
+        nng_msg_free(msg);
+    }
+    return rv;
+}
+
 neu_node_id_t neu_manager_adapter_id_to_node_id(neu_manager_t *manager,
                                                 adapter_id_t   adapter_id)
 {

--- a/src/core/neu_manager.c
+++ b/src/core/neu_manager.c
@@ -1395,55 +1395,8 @@ static void manager_loop(void *arg)
         }
 
         case MSG_CMD_UNSUBSCRIBE_NODE: {
-            size_t       msg_size;
-            nng_msg *    out_msg;
-            nng_pipe     msg_pipe;
-            int          need_forward;
-            adapter_id_t src_adapter_id;
-            adapter_id_t sub_adapter_id;
-
-            unsubscribe_node_cmd_t *cmd_ptr;
-            adapter_reg_entity_t *  src_reg_entity;
-            adapter_reg_entity_t *  sub_reg_entity;
-
-            cmd_ptr = (unsubscribe_node_cmd_t *) msg_get_buf_ptr(pay_msg);
-            nng_mtx_lock(manager->adapters_mtx);
-            src_adapter_id = neu_manager_adapter_id_from_node_id(
-                manager, cmd_ptr->src_node_id);
-            sub_adapter_id = neu_manager_adapter_id_from_node_id(
-                manager, cmd_ptr->dst_node_id);
-            src_reg_entity =
-                find_reg_adapter_by_id(&manager->reg_adapters, src_adapter_id);
-            sub_reg_entity =
-                find_reg_adapter_by_id(&manager->reg_adapters, sub_adapter_id);
-            neu_adapter_del_sub_grp_config(sub_reg_entity->adapter,
-                                           cmd_ptr->src_node_id,
-                                           cmd_ptr->grp_config);
-            msg_pipe = src_reg_entity->adapter_pipe;
-            nng_mtx_unlock(manager->adapters_mtx);
-            need_forward = unsub_grp_config_with_pipe(
-                cmd_ptr->grp_config, sub_reg_entity->adapter_pipe);
-            if (0 == need_forward) {
-                break;
-            }
-
-            msg_size =
-                msg_inplace_data_get_size(sizeof(unsubscribe_node_cmd_t));
-            rv = nng_msg_alloc(&out_msg, msg_size);
-            if (rv == 0) {
-                message_t *             msg_ptr;
-                unsubscribe_node_cmd_t *out_cmd_ptr;
-                msg_ptr = (message_t *) nng_msg_body(out_msg);
-                msg_inplace_data_init(msg_ptr, MSG_CMD_UNSUBSCRIBE_NODE,
-                                      sizeof(unsubscribe_node_cmd_t));
-                out_cmd_ptr = msg_get_buf_ptr(msg_ptr);
-                memcpy(out_cmd_ptr, cmd_ptr, sizeof(unsubscribe_node_cmd_t));
-                nng_msg_set_pipe(out_msg, msg_pipe);
-                log_info(
-                    "Forward unsubscribe driver command to driver pipe: %d",
-                    msg_pipe);
-                nng_sendmsg(manager_bind->mng_sock, out_msg, 0);
-            }
+            unsubscribe_node_cmd_t *cmd_ptr = msg_get_buf_ptr(pay_msg);
+            neu_manager_unsubscribe_node(manager, cmd_ptr);
             break;
         }
 
@@ -1791,6 +1744,50 @@ int neu_manager_subscribe_node(neu_manager_t *       manager,
         memcpy(out_cmd_ptr, cmd, sizeof(subscribe_node_cmd_t));
         nng_msg_set_pipe(out_msg, src_reg_entity->adapter_pipe);
         log_info("Forward subscribe driver command to driver pipe: %d",
+                 src_reg_entity->adapter_pipe);
+        nng_sendmsg(manager->bind_info.mng_sock, out_msg, 0);
+    }
+
+    return rv;
+}
+
+int neu_manager_unsubscribe_node(neu_manager_t *         manager,
+                                 unsubscribe_node_cmd_t *cmd)
+{
+    int rv = 0;
+
+    nng_mtx_lock(manager->adapters_mtx);
+    adapter_id_t src_adapter_id =
+        neu_manager_adapter_id_from_node_id(manager, cmd->src_node_id);
+    adapter_id_t sub_adapter_id =
+        neu_manager_adapter_id_from_node_id(manager, cmd->dst_node_id);
+    adapter_reg_entity_t *src_reg_entity =
+        find_reg_adapter_by_id(&manager->reg_adapters, src_adapter_id);
+    adapter_reg_entity_t *sub_reg_entity =
+        find_reg_adapter_by_id(&manager->reg_adapters, sub_adapter_id);
+    neu_adapter_del_sub_grp_config(sub_reg_entity->adapter, cmd->src_node_id,
+                                   cmd->grp_config);
+    nng_mtx_unlock(manager->adapters_mtx);
+
+    int need_forward = unsub_grp_config_with_pipe(cmd->grp_config,
+                                                  sub_reg_entity->adapter_pipe);
+    if (0 == need_forward) {
+        return rv;
+    }
+
+    size_t msg_size = msg_inplace_data_get_size(sizeof(unsubscribe_node_cmd_t));
+    nng_msg *out_msg = NULL;
+    rv               = nng_msg_alloc(&out_msg, msg_size);
+    if (rv == 0) {
+        message_t *             msg_ptr;
+        unsubscribe_node_cmd_t *out_cmd_ptr;
+        msg_ptr = (message_t *) nng_msg_body(out_msg);
+        msg_inplace_data_init(msg_ptr, MSG_CMD_UNSUBSCRIBE_NODE,
+                              sizeof(unsubscribe_node_cmd_t));
+        out_cmd_ptr = msg_get_buf_ptr(msg_ptr);
+        memcpy(out_cmd_ptr, cmd, sizeof(unsubscribe_node_cmd_t));
+        nng_msg_set_pipe(out_msg, src_reg_entity->adapter_pipe);
+        log_info("Forward unsubscribe driver command to driver pipe: %d",
                  src_reg_entity->adapter_pipe);
         nng_sendmsg(manager->bind_info.mng_sock, out_msg, 0);
     }

--- a/src/core/neu_manager.c
+++ b/src/core/neu_manager.c
@@ -1415,11 +1415,15 @@ static void manager_loop(void *arg)
                                            cmd_ptr->grp_config);
             msg_pipe = src_reg_entity->adapter_pipe;
             nng_mtx_unlock(manager->adapters_mtx);
-            msg_size = msg_inplace_data_get_size(sizeof(subscribe_node_cmd_t));
-            rv       = nng_msg_alloc(&out_msg, msg_size);
             need_forward = sub_grp_config_with_pipe(
                 cmd_ptr->grp_config, sub_reg_entity->adapter_pipe);
-            if (rv == 0 && need_forward == 1) {
+            if (0 == need_forward) {
+                break;
+            }
+
+            msg_size = msg_inplace_data_get_size(sizeof(subscribe_node_cmd_t));
+            rv       = nng_msg_alloc(&out_msg, msg_size);
+            if (rv == 0) {
                 message_t *           msg_ptr;
                 subscribe_node_cmd_t *out_cmd_ptr;
                 msg_ptr = (message_t *) nng_msg_body(out_msg);
@@ -1462,12 +1466,16 @@ static void manager_loop(void *arg)
                                            cmd_ptr->grp_config);
             msg_pipe = src_reg_entity->adapter_pipe;
             nng_mtx_unlock(manager->adapters_mtx);
-            msg_size =
-                msg_inplace_data_get_size(sizeof(unsubscribe_node_cmd_t));
-            rv           = nng_msg_alloc(&out_msg, msg_size);
             need_forward = unsub_grp_config_with_pipe(
                 cmd_ptr->grp_config, sub_reg_entity->adapter_pipe);
-            if (rv == 0 && need_forward == 1) {
+            if (0 == need_forward) {
+                break;
+            }
+
+            msg_size =
+                msg_inplace_data_get_size(sizeof(unsubscribe_node_cmd_t));
+            rv = nng_msg_alloc(&out_msg, msg_size);
+            if (rv == 0) {
                 message_t *             msg_ptr;
                 unsubscribe_node_cmd_t *out_cmd_ptr;
                 msg_ptr = (message_t *) nng_msg_body(out_msg);

--- a/src/core/neu_manager.h
+++ b/src/core/neu_manager.h
@@ -25,7 +25,8 @@
 
 #define DEFAULT_ADAPTER_REG_COUNT 8
 
-typedef struct neu_manager neu_manager_t;
+typedef struct neu_manager          neu_manager_t;
+typedef struct subscribe_driver_cmd subscribe_node_cmd_t;
 
 typedef void (*bind_notify_fun)(nng_pipe p, nng_pipe_ev ev, void *arg);
 
@@ -45,6 +46,8 @@ int neu_manager_get_nodes(neu_manager_t *manager, neu_node_type_e node_type,
                           vector_t *result_nodes);
 int neu_manager_get_node_name_by_id(neu_manager_t *manager,
                                     neu_node_id_t node_id, char **name);
+int neu_manager_subscribe_node(neu_manager_t *       manager,
+                               subscribe_node_cmd_t *cmd);
 
 int neu_manager_add_grp_config(neu_manager_t *           manager,
                                neu_cmd_add_grp_config_t *cmd);

--- a/src/core/neu_manager.h
+++ b/src/core/neu_manager.h
@@ -25,8 +25,9 @@
 
 #define DEFAULT_ADAPTER_REG_COUNT 8
 
-typedef struct neu_manager          neu_manager_t;
-typedef struct subscribe_driver_cmd subscribe_node_cmd_t;
+typedef struct neu_manager            neu_manager_t;
+typedef struct subscribe_driver_cmd   subscribe_node_cmd_t;
+typedef struct unsubscribe_driver_cmd unsubscribe_node_cmd_t;
 
 typedef void (*bind_notify_fun)(nng_pipe p, nng_pipe_ev ev, void *arg);
 
@@ -48,6 +49,8 @@ int neu_manager_get_node_name_by_id(neu_manager_t *manager,
                                     neu_node_id_t node_id, char **name);
 int neu_manager_subscribe_node(neu_manager_t *       manager,
                                subscribe_node_cmd_t *cmd);
+int neu_manager_unsubscribe_node(neu_manager_t *         manager,
+                                 unsubscribe_node_cmd_t *cmd);
 
 int neu_manager_add_grp_config(neu_manager_t *           manager,
                                neu_cmd_add_grp_config_t *cmd);


### PR DESCRIPTION
1. Refactor neu_manager loop MSG_CMD_SUBSCRIBE_NODE handler code
2. Refactor neu_manager loop MSG_CMD_UNSUBSCRIBE_NODE handler code
3. Cache persist adapter pipe in neu_manager loop for performance
4. Add function nng_msg_inplace_from_buf
5. Add helper function manager_send_msg_to_pipe
6. Refactor neu_manager loop persistence event forwarding code