### PR TITLE
Remove redundant fields from plugin persistence.

### DIFF
--- a/docs/json-persistence/json_plugin.json
+++ b/docs/json-persistence/json_plugin.json
@@ -1,46 +1,14 @@
 {
     "plugin_req": {
         "plugins": [
-            {
-                "kind": 1,
-                "adapter_type": 1,
-                "name": "sample-drv-plugin",
-                "plugin_lib_name": "libplugin-sample-drv.so"
-            },
-            {
-                "kind": 1,
-                "adapter_type": 5,
-                "name": "sample-app-plugin",
-                "plugin_lib_name": "libplugin-sample-app.so"
-            },
-            {
-                "kind": 1,
-                "adapter_type": 3,
-                "name": "mqtt-plugin",
-                "plugin_lib_name": "libplugin-mqtt.so"
-            }
+            "libplugin-mqtt.so",
+            "libplugin-modbus-tcp.so"
         ]
     },
     "plugin_resp": {
         "plugins": [
-            {
-                "kind": 1,
-                "adapter_type": 1,
-                "name": "sample-drv-plugin",
-                "plugin_lib_name": "libplugin-sample-drv.so"
-            },
-            {
-                "kind": 1,
-                "adapter_type": 5,
-                "name": "sample-app-plugin",
-                "plugin_lib_name": "libplugin-sample-app.so"
-            },
-            {
-                "kind": 1,
-                "adapter_type": 3,
-                "name": "mqtt-plugin",
-                "plugin_lib_name": "libplugin-mqtt.so"
-            }
+            "libplugin-mqtt.so",
+            "libplugin-modbus-tcp.so"
         ]
     }
 }

--- a/src/adapter/adapter.c
+++ b/src/adapter/adapter.c
@@ -213,19 +213,17 @@ static int persister_singleton_load_plugins(neu_adapter_t *adapter)
     }
     VECTOR_FOR_EACH(plugin_infos, iter)
     {
-        neu_persist_plugin_info_t *plugin_info    = iterator_get(&iter);
-        plugin_id_t                plugin_id      = {};
-        neu_cmd_add_plugin_lib_t   add_plugin_cmd = {
-            .plugin_lib_name = plugin_info->plugin_lib_name,
+        char **                  plugin_info    = (char **) iterator_get(&iter);
+        plugin_id_t              plugin_id      = {};
+        neu_cmd_add_plugin_lib_t add_plugin_cmd = {
+            .plugin_lib_name = *plugin_info,
         };
 
         rv = neu_manager_add_plugin_lib(adapter->manager, &add_plugin_cmd,
                                         &plugin_id);
         const char *ok_or_err = (0 == rv) ? "success" : "fail";
-        log_info("%s load plugin %s type:%d, kind:%d name:%s lib:%s",
-                 adapter->name, ok_or_err, plugin_info->adapter_type,
-                 plugin_info->kind, plugin_info->name,
-                 plugin_info->plugin_lib_name);
+        log_info("%s load plugin %s , lib:%s", adapter->name, ok_or_err,
+                 *plugin_info);
         if (0 != rv) {
             break;
         }

--- a/src/core/neu_manager.c
+++ b/src/core/neu_manager.c
@@ -2205,26 +2205,21 @@ int neu_manager_get_persist_plugin_infos(neu_manager_t *manager,
     if (count >= DEFAULT_PLUGIN_INFO_SIZE) {
         count -= DEFAULT_PLUGIN_INFO_SIZE;
     }
-    vector_t *plugin_infos =
-        vector_new(count, sizeof(neu_persist_adapter_info_t));
+    vector_t *plugin_infos = vector_new(count, sizeof(char *));
     if (NULL == plugin_infos) {
         vector_free(plugin_regs);
         return NEU_ERR_ENOMEM;
     }
 
-    neu_persist_plugin_info_t plugin_info     = {};
-    plugin_reg_info_t *       plugin_reg_info = NULL;
+    char *             plugin_info     = NULL;
+    plugin_reg_info_t *plugin_reg_info = NULL;
     VECTOR_FOR_EACH(plugin_regs, iter)
     {
         plugin_reg_info = (plugin_reg_info_t *) iterator_get(&iter);
         if (is_default_plugin(plugin_reg_info->plugin_name)) {
             continue;
         }
-        adapter_type_e adapter_type = plugin_reg_info->adapter_type;
-        plugin_info.kind            = plugin_reg_info->plugin_kind;
-        plugin_info.adapter_type    = adapter_type_to_node_type(adapter_type);
-        plugin_info.name            = strdup(plugin_reg_info->plugin_name);
-        plugin_info.plugin_lib_name = strdup(plugin_reg_info->plugin_lib_name);
+        plugin_info = strdup(plugin_reg_info->plugin_lib_name);
         if (0 != vector_push_back(plugin_infos, &plugin_info)) {
             neu_persist_plugin_infos_free(plugin_infos);
             vector_free(plugin_regs);

--- a/src/persist/json/persist_json_plugin.c
+++ b/src/persist/json/persist_json_plugin.c
@@ -45,21 +45,9 @@ int neu_json_decode_plugin_req(char *buf, neu_json_plugin_req_t **result)
     neu_json_plugin_req_plugin_t *p_plugin = req->plugins;
     for (int i = 0; i < req->n_plugin; i++) {
         neu_json_elem_t plugin_elems[] = { {
-                                               .name = "plugin_lib_name",
-                                               .t    = NEU_JSON_STR,
-                                           },
-                                           {
-                                               .name = "name",
-                                               .t    = NEU_JSON_STR,
-                                           },
-                                           {
-                                               .name = "kind",
-                                               .t    = NEU_JSON_INT,
-                                           },
-                                           {
-                                               .name = "adapter_type",
-                                               .t    = NEU_JSON_INT,
-                                           } };
+            .name = NULL,
+            .t    = NEU_JSON_STR,
+        } };
         ret = neu_json_decode_array_by_json(json_obj, "plugins", i,
                                             NEU_JSON_ELEM_SIZE(plugin_elems),
                                             plugin_elems);
@@ -67,10 +55,7 @@ int neu_json_decode_plugin_req(char *buf, neu_json_plugin_req_t **result)
             goto decode_fail;
         }
 
-        p_plugin->plugin_lib_name = plugin_elems[0].v.val_str;
-        p_plugin->name            = plugin_elems[1].v.val_str;
-        p_plugin->kind            = plugin_elems[2].v.val_int;
-        p_plugin->adapter_type    = plugin_elems[3].v.val_int;
+        *p_plugin = plugin_elems[0].v.val_str;
         p_plugin++;
     }
 
@@ -98,8 +83,7 @@ void neu_json_decode_plugin_req_free(neu_json_plugin_req_t *req)
 
     neu_json_plugin_req_plugin_t *p_plugin = req->plugins;
     for (int i = 0; i < req->n_plugin; i++) {
-        free(p_plugin->plugin_lib_name);
-        free(p_plugin->name);
+        free(*p_plugin);
         p_plugin++;
     }
 
@@ -116,30 +100,13 @@ int neu_json_encode_plugin_resp(void *json_object, void *param)
     void *                         plugin_array = neu_json_array();
     neu_json_plugin_resp_plugin_t *p_plugin     = resp->plugins;
     for (int i = 0; i < resp->n_plugin; i++) {
-        neu_json_elem_t plugin_elems[] = {
-            {
-                .name      = "plugin_lib_name",
-                .t         = NEU_JSON_STR,
-                .v.val_str = p_plugin->plugin_lib_name,
-            },
-            {
-                .name      = "name",
-                .t         = NEU_JSON_STR,
-                .v.val_str = p_plugin->name,
-            },
-            {
-                .name      = "kind",
-                .t         = NEU_JSON_INT,
-                .v.val_int = p_plugin->kind,
-            },
-            {
-                .name      = "adapter_type",
-                .t         = NEU_JSON_INT,
-                .v.val_int = p_plugin->adapter_type,
-            }
-        };
-        plugin_array = neu_json_encode_array(plugin_array, plugin_elems,
-                                             NEU_JSON_ELEM_SIZE(plugin_elems));
+        neu_json_elem_t plugin_elems[] = { {
+            .name      = NULL,
+            .t         = NEU_JSON_STR,
+            .v.val_str = *p_plugin,
+        } };
+        plugin_array                   = neu_json_encode_array_value(
+            plugin_array, plugin_elems, NEU_JSON_ELEM_SIZE(plugin_elems));
         p_plugin++;
     }
 

--- a/src/persist/json/persist_json_plugin.h
+++ b/src/persist/json/persist_json_plugin.h
@@ -31,12 +31,7 @@
 extern "C" {
 #endif
 
-typedef struct {
-    char *  name;
-    int64_t adapter_type;
-    char *  plugin_lib_name;
-    int64_t kind;
-} neu_json_plugin_req_plugin_t;
+typedef char *neu_json_plugin_req_plugin_t;
 
 typedef struct {
     int                           n_plugin;
@@ -46,12 +41,7 @@ typedef struct {
 int  neu_json_decode_plugin_req(char *buf, neu_json_plugin_req_t **result);
 void neu_json_decode_plugin_req_free(neu_json_plugin_req_t *req);
 
-typedef struct {
-    char *  name;
-    int64_t adapter_type;
-    char *  plugin_lib_name;
-    int64_t kind;
-} neu_json_plugin_resp_plugin_t;
+typedef char *neu_json_plugin_resp_plugin_t;
 
 typedef struct {
     int                            n_plugin;

--- a/src/persist/persist.h
+++ b/src/persist/persist.h
@@ -57,8 +57,7 @@ static inline void neu_persist_plugin_infos_free(vector_t *plugin_infos)
     {
         neu_persist_plugin_info_t *p =
             (neu_persist_plugin_info_t *) iterator_get(&iter);
-        free(p->name);
-        free(p->plugin_lib_name);
+        free(*p);
     }
     vector_free(plugin_infos);
 }

--- a/tests/json_persistence_test.cc
+++ b/tests/json_persistence_test.cc
@@ -47,35 +47,17 @@ TEST(JsonAdapter, AdapterPersistenceDecode)
 TEST(JsonPlugin, PluginPersistenceDecode)
 {
     char *buf =
-        (char
-             *) "{\"plugins\": "
-                "[{\"kind\": 1, \"adapter_type\": 1, \"name\": "
-                "\"sample-drv-plugin\", \"plugin_lib_name\": "
-                "\"libplugin-sample-drv.so\"}, "
-                "{\"kind\": 1, \"adapter_type\": 5, \"name\": "
-                "\"sample-app-plugin\", \"plugin_lib_name\": "
-                "\"libplugin-sample-app.so\"}, "
-                "{\"kind\": 1, \"adapter_type\": 3, \"name\": \"mqtt-plugin\", "
-                "\"plugin_lib_name\": \"libplugin-mqtt.so\" }]}";
+        (char *) "{\"plugins\": "
+                 "[ \"libplugin-sample-drv.so\", \"libplugin-sample-app.so\", "
+                 "\"libplugin-mqtt.so\" ]}";
 
     neu_json_plugin_req_t *req = NULL;
 
     EXPECT_EQ(0, neu_json_decode_plugin_req(buf, &req));
 
-    EXPECT_EQ(1, req->plugins[0].kind);
-    EXPECT_EQ(1, req->plugins[0].adapter_type);
-    EXPECT_STREQ("sample-drv-plugin", req->plugins[0].name);
-    EXPECT_STREQ("libplugin-sample-drv.so", req->plugins[0].plugin_lib_name);
-
-    EXPECT_EQ(1, req->plugins[1].kind);
-    EXPECT_EQ(5, req->plugins[1].adapter_type);
-    EXPECT_STREQ("sample-app-plugin", req->plugins[1].name);
-    EXPECT_STREQ("libplugin-sample-app.so", req->plugins[1].plugin_lib_name);
-
-    EXPECT_EQ(1, req->plugins[2].kind);
-    EXPECT_EQ(3, req->plugins[2].adapter_type);
-    EXPECT_STREQ("mqtt-plugin", req->plugins[2].name);
-    EXPECT_STREQ("libplugin-mqtt.so", req->plugins[2].plugin_lib_name);
+    EXPECT_STREQ("libplugin-sample-drv.so", req->plugins[0]);
+    EXPECT_STREQ("libplugin-sample-app.so", req->plugins[1]);
+    EXPECT_STREQ("libplugin-mqtt.so", req->plugins[2]);
 
     neu_json_decode_plugin_req_free(req);
 }
@@ -229,14 +211,8 @@ TEST(JsonAdapterTest, AdapterPersistenceEncode)
 
 TEST(JsonPluginTest, PluginPersistenceEncode)
 {
-    char *buf =
-        (char *) "{\"plugins\": [{\"plugin_lib_name\": "
-                 "\"libplugin-sample-drv.so\", \"name\": "
-                 "\"sample-drv-plugin\", \"kind\": 1, \"adapter_type\": 1}, "
-                 "{\"plugin_lib_name\": \"libplugin-sample-app.so\", \"name\": "
-                 "\"sample-app-plugin\", \"kind\": 1, \"adapter_type\": 5}, "
-                 "{\"plugin_lib_name\": \"libplugin-mqtt.so\", \"name\": "
-                 "\"mqtt-plugin\", \"kind\": 1, \"adapter_type\": 3}]}";
+    char *buf = (char *) "{\"plugins\": [\"libplugin-sample-drv.so\", "
+                         "\"libplugin-sample-app.so\", \"libplugin-mqtt.so\"]}";
     char *buf2 = (char *) "{\"plugins\": []}";
 
     char *result  = NULL;
@@ -251,20 +227,10 @@ TEST(JsonPluginTest, PluginPersistenceEncode)
 
     resp.plugins = (neu_json_plugin_resp_plugin_t *) calloc(
         3, sizeof(neu_json_plugin_resp_plugin_t));
-    resp.plugins[0].kind            = 1;
-    resp.plugins[0].adapter_type    = 1;
-    resp.plugins[0].name            = strdup("sample-drv-plugin");
-    resp.plugins[0].plugin_lib_name = strdup("libplugin-sample-drv.so");
 
-    resp.plugins[1].kind            = 1;
-    resp.plugins[1].adapter_type    = 5;
-    resp.plugins[1].name            = strdup("sample-app-plugin");
-    resp.plugins[1].plugin_lib_name = strdup("libplugin-sample-app.so");
-
-    resp.plugins[2].kind            = 1;
-    resp.plugins[2].adapter_type    = 3;
-    resp.plugins[2].name            = strdup("mqtt-plugin");
-    resp.plugins[2].plugin_lib_name = strdup("libplugin-mqtt.so");
+    resp.plugins[0] = strdup("libplugin-sample-drv.so");
+    resp.plugins[1] = strdup("libplugin-sample-app.so");
+    resp.plugins[2] = strdup("libplugin-mqtt.so");
 
     EXPECT_EQ(
         0, neu_json_encode_by_fn(&resp, neu_json_encode_plugin_resp, &result));
@@ -275,12 +241,9 @@ TEST(JsonPluginTest, PluginPersistenceEncode)
     EXPECT_STREQ(buf, result);
     EXPECT_STREQ(buf2, result2);
 
-    free(resp.plugins[0].name);
-    free(resp.plugins[0].plugin_lib_name);
-    free(resp.plugins[1].name);
-    free(resp.plugins[1].plugin_lib_name);
-    free(resp.plugins[2].name);
-    free(resp.plugins[2].plugin_lib_name);
+    free(resp.plugins[0]);
+    free(resp.plugins[1]);
+    free(resp.plugins[2]);
     free(resp.plugins);
 
     free(result);

--- a/tests/persistence_test.cc
+++ b/tests/persistence_test.cc
@@ -81,14 +81,11 @@ TEST(PersistencePluginTest, Plugin)
     const char *adapters_fname   = neu_persister_get_adapters_fname(persister);
     const char *plugins_fname    = neu_persister_get_plugins_fname(persister);
 
-    neu_json_plugin_req_plugin_t plugin1 = { (char *) "sample-drv-plugin", 1,
-                                             (char *) "libplugin-sample-drv.so",
-                                             1 };
-    neu_json_plugin_req_plugin_t plugin2 = { (char *) "sample-app-plugin", 5,
-                                             (char *) "libplugin-sample-app.so",
-                                             1 };
-    neu_json_plugin_req_plugin_t plugin3 = { (char *) "mqtt-plugin", 3,
-                                             (char *) "libplugin-mqtt.so", 1 };
+    neu_json_plugin_req_plugin_t plugin1 = { (
+        char *) "libplugin-sample-drv.so" };
+    neu_json_plugin_req_plugin_t plugin2 = { (
+        char *) "libplugin-sample-app.so" };
+    neu_json_plugin_req_plugin_t plugin3 = { (char *) "libplugin-mqtt.so" };
 
     neu_json_plugin_req_t *req =
         (neu_json_plugin_req_t *) malloc(sizeof(neu_json_plugin_req_t));
@@ -112,24 +109,16 @@ TEST(PersistencePluginTest, Plugin)
         neu_json_plugin_req_plugin_t *info =
             (neu_json_plugin_req_plugin_t *) iterator_get(&iter);
 
-        if (strcmp(info->name, "sample-drv-plugin") == 0) {
-            EXPECT_STREQ("libplugin-sample-drv.so", info->plugin_lib_name);
-            EXPECT_EQ(1, info->adapter_type);
-            EXPECT_EQ(1, info->kind);
-        } else if (strcmp(info->name, "sample-app-plugin") == 0) {
-            EXPECT_STREQ("libplugin-sample-app.so", info->plugin_lib_name);
-            EXPECT_EQ(5, info->adapter_type);
-            EXPECT_EQ(1, info->kind);
-        } else if (strcmp(info->name, "mqtt-plugin") == 0) {
-            EXPECT_STREQ("libplugin-mqtt.so", info->plugin_lib_name);
-            EXPECT_EQ(3, info->adapter_type);
-            EXPECT_EQ(1, info->kind);
+        if (strcmp(*info, "libplugin-sample-drv.so") == 0) {
+            EXPECT_STREQ("libplugin-sample-drv.so", *info);
+        } else if (strcmp(*info, "libplugin-sample-app.so") == 0) {
+            EXPECT_STREQ("libplugin-sample-app.so", *info);
+        } else if (strcmp(*info, "libplugin-mqtt.so") == 0) {
+            EXPECT_STREQ("libplugin-mqtt.so", *info);
         } else {
             EXPECT_EQ(1, 2);
         }
-
-        free(info->name);
-        free(info->plugin_lib_name);
+        free(*info);
     }
 
     vector_free(plugins);


### PR DESCRIPTION
Remove redundant fields from plugin persistence and keep only plugin_lib_name.